### PR TITLE
Add alias to messages

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -52,6 +52,7 @@ Responses:
     Options: 
       Quantity: 1
   - Response:
+    Alias: "deadLetter"
     Request:
       To: "/otherTest"
       Matchers:

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ type Configuration struct {
 
 // Request configuration
 type Request struct {
+	Alias   string
 	To      string
 	From    string
 	Type    string

--- a/config/response.go
+++ b/config/response.go
@@ -2,6 +2,7 @@ package config
 
 // Response configuration
 type Response struct {
+	Alias           string
 	To              string
 	ResponseRequest ResponseRequest `json:"request" yaml:"request" mapstructure:"request"`
 	Body            Body

--- a/prototype/message_prototype.go
+++ b/prototype/message_prototype.go
@@ -10,6 +10,7 @@ import (
 
 // MessagePrototype is a template for message with mediators, bodyTemplate and headers
 type MessagePrototype struct {
+	Alias string
 	// Headers is a map of headers
 	// Optional and used mostly in HTTP requests
 	Headers map[string]string

--- a/prototype/request_prototype_builder.go
+++ b/prototype/request_prototype_builder.go
@@ -21,6 +21,7 @@ func (b *RequestPrototypeBuilder) Build() []MessagePrototype {
 	for _, request := range b.requestConfig {
 		bodyTemplate := buildBodyTemplate(request.Body)
 		prototypes = append(prototypes, MessagePrototype{
+			Alias:        request.Alias,
 			Type:         request.Type,
 			BodyTemplate: bodyTemplate,
 			Mediators:    buildMediators(bodyTemplate, request.Options),

--- a/prototype/request_prototype_builder_test.go
+++ b/prototype/request_prototype_builder_test.go
@@ -22,9 +22,10 @@ func TestOnValidRequestConfigRequestPrototypeIsBuilt(t *testing.T) {
 	// Given
 	requestConfig := []config.Request{
 		{
-			To: "test",
+			Alias: "testAlias",
+			To:    "testTo",
 			Body: config.Body{
-				String: []string{"test"},
+				String: []string{"testBody"},
 			},
 		},
 	}
@@ -34,6 +35,7 @@ func TestOnValidRequestConfigRequestPrototypeIsBuilt(t *testing.T) {
 
 	// Then
 	assert.Equal(t, 1, len(requestPrototypes))
-	assert.Equal(t, "test", requestPrototypes[0].To)
-	assert.Equal(t, "test", requestPrototypes[0].BodyTemplate[0])
+	assert.Equal(t, "testAlias", requestPrototypes[0].Alias)
+	assert.Equal(t, "testTo", requestPrototypes[0].To)
+	assert.Equal(t, "testBody", requestPrototypes[0].BodyTemplate[0])
 }

--- a/prototype/response_prototype_builder_test.go
+++ b/prototype/response_prototype_builder_test.go
@@ -59,6 +59,7 @@ func TestMultipleResponsesCreatedOnValidConfiguration(t *testing.T) {
 	}
 	responseConfig := []config.Response{
 		{
+			Alias: "testAlias",
 			ResponseRequest: config.ResponseRequest{
 				To:       "test",
 				Matchers: []config.Matcher{fieldMatcher1},
@@ -80,6 +81,7 @@ func TestMultipleResponsesCreatedOnValidConfiguration(t *testing.T) {
 	// Then
 	assert.Equal(t, 2, len(responsePrototypes))
 	assertPrototype(t, "test", responsePrototypes[0])
+	assert.Equal(t, "testAlias", responsePrototypes[0].Alias)
 	assertPrototype(t, "test2", responsePrototypes[1])
 }
 


### PR DESCRIPTION
In order to be able to support changes of the requests and responses in future - adding optional "alias" field to both request and response types. 